### PR TITLE
Add GitHub Actions workflow to fetch GSC data daily

### DIFF
--- a/.github/workflows/fetch-gsc-data.yml
+++ b/.github/workflows/fetch-gsc-data.yml
@@ -1,0 +1,50 @@
+name: Fetch GSC Data
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    # Allow manual trigger from GitHub UI
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-gsc-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install googleapis
+
+      - name: Decode Google credentials
+        env:
+          GOOGLE_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_CREDENTIALS_BASE64 }}
+        run: |
+          echo "$GOOGLE_CREDENTIALS_BASE64" | base64 -d > /tmp/google-credentials.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/google-credentials.json" >> $GITHUB_ENV
+
+      - name: Fetch GSC data
+        run: node scripts/fetch-gsc-data.js
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/gsc-*.json
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update GSC data $(date -u +%Y-%m-%d)"
+            git push
+          fi

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,2 @@
+# This directory stores cached GSC data fetched by GitHub Actions
+# See .github/workflows/fetch-gsc-data.yml

--- a/scripts/fetch-gsc-data.js
+++ b/scripts/fetch-gsc-data.js
@@ -7,13 +7,39 @@
 const { google } = require('googleapis');
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 
+// Rate limit helper - URL Inspection API has quota limits
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Fetch and parse sitemap XML to get all URLs
+async function fetchSitemapUrls(sitemapUrl) {
+  return new Promise((resolve, reject) => {
+    https.get(sitemapUrl, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        // Simple XML parsing for <loc> tags
+        const urls = [];
+        const locMatches = data.matchAll(/<loc>([^<]+)<\/loc>/g);
+        for (const match of locMatches) {
+          urls.push(match[1]);
+        }
+        resolve(urls);
+      });
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
 async function main() {
-  // Setup authentication
+  // Setup authentication - need webmasters scope for URL inspection
   const auth = new google.auth.GoogleAuth({
-    scopes: ['https://www.googleapis.com/auth/webmasters.readonly']
+    scopes: ['https://www.googleapis.com/auth/webmasters']
   });
 
   const client = await auth.getClient();
@@ -126,6 +152,112 @@ async function main() {
         console.log('    (No sitemaps or access denied)');
       }
 
+      // Collect all URLs to inspect (from sitemaps and top pages)
+      console.log('  Collecting URLs for indexing inspection...');
+      let urlsToInspect = new Set();
+
+      // Add URLs from sitemaps
+      for (const sitemap of sitemaps) {
+        if (sitemap.path) {
+          try {
+            const sitemapUrls = await fetchSitemapUrls(sitemap.path);
+            sitemapUrls.forEach(url => urlsToInspect.add(url));
+            console.log(`    Found ${sitemapUrls.length} URLs in ${sitemap.path}`);
+          } catch (e) {
+            console.log(`    Could not fetch sitemap ${sitemap.path}: ${e.message}`);
+          }
+        }
+      }
+
+      // Add top pages from search analytics
+      (pagesRes.data.rows || []).forEach(row => {
+        if (row.keys && row.keys[0]) {
+          urlsToInspect.add(row.keys[0]);
+        }
+      });
+
+      console.log(`  Total unique URLs to inspect: ${urlsToInspect.size}`);
+
+      // Inspect URLs for indexing status (with rate limiting)
+      console.log('  Inspecting URL indexing status...');
+      const indexingResults = [];
+      const indexingIssues = [];
+      let inspectedCount = 0;
+
+      for (const inspectionUrl of urlsToInspect) {
+        try {
+          // Rate limit: ~1 request per 100ms to stay well under quota
+          await sleep(100);
+
+          const inspectRes = await searchconsole.urlInspection.index.inspect({
+            requestBody: {
+              inspectionUrl,
+              siteUrl
+            }
+          });
+
+          const result = inspectRes.data.inspectionResult;
+          inspectedCount++;
+
+          const indexStatus = result?.indexStatusResult;
+          const pageUrl = inspectionUrl;
+
+          // Store result
+          const urlResult = {
+            url: pageUrl,
+            verdict: indexStatus?.verdict || 'UNKNOWN',
+            coverageState: indexStatus?.coverageState || 'UNKNOWN',
+            robotsTxtState: indexStatus?.robotsTxtState,
+            indexingState: indexStatus?.indexingState,
+            lastCrawlTime: indexStatus?.lastCrawlTime,
+            pageFetchState: indexStatus?.pageFetchState,
+            crawledAs: indexStatus?.crawledAs,
+            referringUrls: indexStatus?.referringUrls
+          };
+
+          indexingResults.push(urlResult);
+
+          // Track issues (anything not indexed or with problems)
+          if (indexStatus?.verdict !== 'PASS' || indexStatus?.coverageState !== 'Submitted and indexed') {
+            indexingIssues.push({
+              url: pageUrl,
+              verdict: indexStatus?.verdict,
+              coverageState: indexStatus?.coverageState,
+              reason: indexStatus?.coverageState || indexStatus?.verdict || 'Unknown issue'
+            });
+          }
+
+          // Progress indicator every 50 URLs
+          if (inspectedCount % 50 === 0) {
+            console.log(`    Inspected ${inspectedCount}/${urlsToInspect.size} URLs...`);
+          }
+
+        } catch (e) {
+          // Log but continue on individual URL errors
+          if (e.message.includes('quota') || e.message.includes('rate')) {
+            console.log(`    Rate limit hit after ${inspectedCount} URLs, stopping inspection`);
+            break;
+          }
+          indexingResults.push({
+            url: inspectionUrl,
+            verdict: 'ERROR',
+            error: e.message
+          });
+        }
+      }
+
+      console.log(`  Inspected ${inspectedCount} URLs, found ${indexingIssues.length} with issues`);
+
+      // Aggregate issues by type
+      const issuesByType = {};
+      for (const issue of indexingIssues) {
+        const key = issue.reason || 'Unknown';
+        if (!issuesByType[key]) {
+          issuesByType[key] = [];
+        }
+        issuesByType[key].push(issue.url);
+      }
+
       // Compile all data
       const siteData = {
         fetchedAt: new Date().toISOString(),
@@ -137,14 +269,25 @@ async function main() {
           avgCtr: dailyRes.data.rows?.length ?
             dailyRes.data.rows.reduce((sum, r) => sum + r.ctr, 0) / dailyRes.data.rows.length : 0,
           avgPosition: dailyRes.data.rows?.length ?
-            dailyRes.data.rows.reduce((sum, r) => sum + r.position, 0) / dailyRes.data.rows.length : 0
+            dailyRes.data.rows.reduce((sum, r) => sum + r.position, 0) / dailyRes.data.rows.length : 0,
+          totalUrlsInspected: inspectedCount,
+          urlsWithIssues: indexingIssues.length
         },
         topQueries: queriesRes.data.rows || [],
         topPages: pagesRes.data.rows || [],
         byCountry: countriesRes.data.rows || [],
         byDevice: devicesRes.data.rows || [],
         dailyPerformance: dailyRes.data.rows || [],
-        sitemaps
+        sitemaps,
+        // Indexing status data
+        indexing: {
+          inspectedAt: new Date().toISOString(),
+          totalInspected: inspectedCount,
+          issueCount: indexingIssues.length,
+          issuesByType,
+          issues: indexingIssues,
+          allResults: indexingResults
+        }
       };
 
       // Save site data

--- a/scripts/fetch-gsc-data.js
+++ b/scripts/fetch-gsc-data.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Fetch Google Search Console data and save to JSON files
+ * Run via GitHub Actions on a schedule or manually
+ */
+
+const { google } = require('googleapis');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+
+async function main() {
+  // Setup authentication
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/webmasters.readonly']
+  });
+
+  const client = await auth.getClient();
+  const searchconsole = google.searchconsole({ version: 'v1', auth: client });
+
+  // Get list of sites
+  console.log('Fetching site list...');
+  const sitesRes = await searchconsole.sites.list();
+  const sites = sitesRes.data.siteEntry || [];
+
+  if (sites.length === 0) {
+    console.log('No sites found. Make sure the service account has access to your Search Console property.');
+    console.log('Service account email should be added as a user in Search Console settings.');
+    process.exit(1);
+  }
+
+  console.log(`Found ${sites.length} site(s):`);
+  sites.forEach(s => console.log(`  - ${s.siteUrl} (${s.permissionLevel})`));
+
+  // Save sites list
+  fs.writeFileSync(
+    path.join(DATA_DIR, 'gsc-sites.json'),
+    JSON.stringify({ fetchedAt: new Date().toISOString(), sites }, null, 2)
+  );
+
+  // Fetch data for each site
+  for (const site of sites) {
+    const siteUrl = site.siteUrl;
+    const safeName = siteUrl.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+
+    console.log(`\nFetching data for ${siteUrl}...`);
+
+    // Calculate date range (last 28 days, excluding last 3 days for data freshness)
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() - 3);
+    const startDate = new Date(endDate);
+    startDate.setDate(startDate.getDate() - 28);
+
+    const dateRange = {
+      startDate: startDate.toISOString().split('T')[0],
+      endDate: endDate.toISOString().split('T')[0]
+    };
+
+    try {
+      // Fetch search analytics - top queries
+      console.log('  Fetching top queries...');
+      const queriesRes = await searchconsole.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          ...dateRange,
+          dimensions: ['query'],
+          rowLimit: 100,
+          dataState: 'final'
+        }
+      });
+
+      // Fetch search analytics - top pages
+      console.log('  Fetching top pages...');
+      const pagesRes = await searchconsole.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          ...dateRange,
+          dimensions: ['page'],
+          rowLimit: 100,
+          dataState: 'final'
+        }
+      });
+
+      // Fetch search analytics - by country
+      console.log('  Fetching by country...');
+      const countriesRes = await searchconsole.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          ...dateRange,
+          dimensions: ['country'],
+          rowLimit: 50,
+          dataState: 'final'
+        }
+      });
+
+      // Fetch search analytics - by device
+      console.log('  Fetching by device...');
+      const devicesRes = await searchconsole.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          ...dateRange,
+          dimensions: ['device'],
+          dataState: 'final'
+        }
+      });
+
+      // Fetch search analytics - daily totals
+      console.log('  Fetching daily performance...');
+      const dailyRes = await searchconsole.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          ...dateRange,
+          dimensions: ['date'],
+          dataState: 'final'
+        }
+      });
+
+      // Fetch sitemaps
+      console.log('  Fetching sitemaps...');
+      let sitemaps = [];
+      try {
+        const sitemapsRes = await searchconsole.sitemaps.list({ siteUrl });
+        sitemaps = sitemapsRes.data.sitemap || [];
+      } catch (e) {
+        console.log('    (No sitemaps or access denied)');
+      }
+
+      // Compile all data
+      const siteData = {
+        fetchedAt: new Date().toISOString(),
+        siteUrl,
+        dateRange,
+        summary: {
+          totalClicks: dailyRes.data.rows?.reduce((sum, r) => sum + r.clicks, 0) || 0,
+          totalImpressions: dailyRes.data.rows?.reduce((sum, r) => sum + r.impressions, 0) || 0,
+          avgCtr: dailyRes.data.rows?.length ?
+            dailyRes.data.rows.reduce((sum, r) => sum + r.ctr, 0) / dailyRes.data.rows.length : 0,
+          avgPosition: dailyRes.data.rows?.length ?
+            dailyRes.data.rows.reduce((sum, r) => sum + r.position, 0) / dailyRes.data.rows.length : 0
+        },
+        topQueries: queriesRes.data.rows || [],
+        topPages: pagesRes.data.rows || [],
+        byCountry: countriesRes.data.rows || [],
+        byDevice: devicesRes.data.rows || [],
+        dailyPerformance: dailyRes.data.rows || [],
+        sitemaps
+      };
+
+      // Save site data
+      const filename = `gsc-${safeName}.json`;
+      fs.writeFileSync(
+        path.join(DATA_DIR, filename),
+        JSON.stringify(siteData, null, 2)
+      );
+      console.log(`  Saved to data/${filename}`);
+
+    } catch (error) {
+      console.error(`  Error fetching data for ${siteUrl}:`, error.message);
+    }
+  }
+
+  console.log('\nDone!');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/fetch-gsc-data.js` to fetch Google Search Console data via API
- Add `.github/workflows/fetch-gsc-data.yml` for daily scheduled runs (6 AM UTC)
- Create `data/` directory for cached GSC data

## Data Collected

**Search Analytics (28-day window):**
- Top 100 queries by performance
- Top 100 pages by performance  
- Traffic by country (top 50)
- Traffic by device type
- Daily performance trends

**Indexing Status:**
- Inspects all URLs from sitemaps + top pages
- Tracks indexing issues (not indexed, crawled but not indexed, etc.)
- Aggregates issues by type for easy review
- Includes rate limiting to stay within API quota

## Setup Required

Add `GOOGLE_CREDENTIALS_BASE64` secret in repo Settings → Secrets → Actions

## Test plan

- [ ] Verify workflow runs manually via Actions → Fetch GSC Data → Run workflow
- [ ] Confirm data files are created in `data/` directory
- [ ] Check indexing issues are properly captured