### PR TITLE
Fix page indexing issues

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,8 @@
 project:
   type: website
   output-dir: _site
+  post-render:
+    - scripts/fix-sitemap.sh
 
 resources:
   - images/seedling_tiny_ps.svg

--- a/scripts/fix-sitemap.sh
+++ b/scripts/fix-sitemap.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Post-render script to fix sitemap URLs
+# Converts /path/index.html → /path/ to match canonical URLs
+
+SITEMAP="_site/sitemap.xml"
+
+if [ -f "$SITEMAP" ]; then
+    echo "Fixing sitemap URLs to match canonical format..."
+
+    # Replace index.html with trailing slash in sitemap
+    # This ensures sitemap URLs match the canonical URLs
+    sed -i 's|/index\.html</loc>|/</loc>|g' "$SITEMAP"
+
+    echo "Sitemap fixed: index.html suffixes removed"
+else
+    echo "Warning: sitemap.xml not found at $SITEMAP"
+fi


### PR DESCRIPTION
Add post-render script that converts /path/index.html URLs to /path/ in the sitemap. This resolves Google Search Console "Alternate page with proper canonical tag" warnings caused by mismatch between sitemap URLs and canonical tags.