### PR TITLE
Fix quick wins from codebase assessment

### DIFF
--- a/docs/aux/index.qmd
+++ b/docs/aux/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Auxiliary Arts"
+description: "Supplementary skills for pharmacometricians including data visualization, scientific writing, presentations, and coding best practices."
 ---
 
 **Auxiliary**:  

--- a/docs/concepts/clinpharm-studies/index.qmd
+++ b/docs/concepts/clinpharm-studies/index.qmd
@@ -50,7 +50,7 @@ In Phase 3, we **confirm** our efficacy and safety hypotheses in the target pop
 George Box views scientific progress as consisting of and requiring alternating steps of induction and deduction: the former is learning from experience, and the latter confirms what has been learned.
 A simplified application of this view to clinical drug development would break development into two learn-confirm cycles @fig-cycles.
 
-![A "Double Diamond" illustrating the two learn-confirm cycles of clinical drug development. After the first cycle, a point is reached where further development is decided upon. Finally, the drug is approved.](../images/learn-confirm-cycles){#fig-cycles}
+![A "Double Diamond" illustrating the two learn-confirm cycles of clinical drug development. After the first cycle, a point is reached where further development is decided upon. Finally, the drug is approved.](../images/learn-confirm-cycles.png){#fig-cycles}
 
 * First cycle (Proof-of-Concept)
   * Phase 1: **Learn** what is the tolerated dose? (Max tolerated dose?)

--- a/docs/encyclopaedia/index.qmd
+++ b/docs/encyclopaedia/index.qmd
@@ -1,3 +1,4 @@
 ---
 title: "Encyclopædia Pharmacometrika"
+description: "Comprehensive pharmacometrics reference covering PK/PD concepts, modeling techniques, drug information, and regulatory guidance."
 ---

--- a/docs/guilds/index.qmd
+++ b/docs/guilds/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Gathering of Guilds"
 subtitle: "Get in contact with the community"
+description: "Directory of pharmacometrics societies, conferences, journals, and professional communities including ISoP, PAGE, and ACoP."
 date: last-modified
 ---
 

--- a/docs/navigation/index.qmd
+++ b/docs/navigation/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Novice's Navigation"
+description: "Getting started in pharmacometrics: career paths, training courses, workshops, and mentoring resources for beginners."
 ---
 
 > It's dangerous to go alone! Take this. 🧭

--- a/docs/pathology-primers/index.qmd
+++ b/docs/pathology-primers/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Pathology Primers"
+description: "Disease overviews for pharmacometricians covering pathophysiology, biomarkers, treatment regimens, and PK/PD modeling approaches."
 ---
 
 ## Disease facts that are good to know

--- a/docs/pharmacopeia/J_antiinfectives-for-systemic-use/J01_antibacterials-for-systemic-use/index.qmd
+++ b/docs/pharmacopeia/J_antiinfectives-for-systemic-use/J01_antibacterials-for-systemic-use/index.qmd
@@ -15,7 +15,7 @@ date: last-modified
 * ABX C_T should be high enough.
 :::
 
-Antibacterials (@fig-abx-classes) are drugs used to treat bacterial infections.
+Antibacterials are drugs used to treat bacterial infections.
 We often use the words *antimicrobials*, *antibacterials*, and *antibiotics* for these compounds.
 They are similar terms, but each has a specific meaning:
 
@@ -27,7 +27,8 @@ The term "antibiotic" comes from the Greek words *anti* ("against") and *biotiko
 Strictly speaking, antibiotics refers only to naturally produced substances, and not synthetic or semi-synthetic types (e.g., quinolones).
 However, it is commonly used interchangeably with antibacterials.
 
-![Types and classes of antibacterials.](../images/abx-classes.png){#fig-abx-classes}
+<!-- TODO: Add image ../images/abx-classes.png -->
+<!-- ![Types and classes of antibacterials.](../images/abx-classes.png){#fig-abx-classes} -->
 
 ## How do antibacterials work?
 
@@ -38,7 +39,8 @@ Antibacterials interfere with vital processes in bacterial cells.
 
 The host's immune system then clears the remaining infecting pathogens.
 
-![Drug-Bug-Host disease triangle.](../images/bug-drug-host_disease-triangle.png){#fig-triangle}
+<!-- TODO: Add image ../images/bug-drug-host_disease-triangle.png -->
+<!-- ![Drug-Bug-Host disease triangle.](../images/bug-drug-host_disease-triangle.png){#fig-triangle} -->
 
 ### Antibiotic targets in bacteria
 

--- a/docs/pharmacopeia/J_antiinfectives-for-systemic-use/J05_antivirals-for-systemic-use/index.qmd
+++ b/docs/pharmacopeia/J_antiinfectives-for-systemic-use/J05_antivirals-for-systemic-use/index.qmd
@@ -6,7 +6,8 @@ date: last-modified
 :::{.callout-caution title="Under construction"}
 :::
 
-![](../images/antivirals.png){#fig-antivirals}
+<!-- TODO: Add image ../images/antivirals.png -->
+<!-- ![](../images/antivirals.png){#fig-antivirals} -->
 
 | J05 | ANTIVIRALS FOR SYSTEMIC USE |
 | :--- | :--- |

--- a/docs/pharmacopeia/index.qmd
+++ b/docs/pharmacopeia/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Pharmacopœia Pharmacometrika"
+description: "Drug classification reference using the ATC system with mechanism of action, drug classes, and pharmacological properties."
 date: last-modified
 ---
 

--- a/docs/references/index.qmd
+++ b/docs/references/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "References"
 subtitle: "All the information you need to learn more about the topics covered on this page."
+description: "Bibliography and references for pharmacometrics topics including key publications and learning resources."
 date: last-modified
 ---
 

--- a/docs/regulatory/index.qmd
+++ b/docs/regulatory/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Regulatory Rites"
+description: "Regulatory science for pharmacometricians: GCP guidelines, EMA submission workflows, SmPC structure, and compliance requirements."
 date: last-modified
 ---
 

--- a/docs/tools-of-the-trade/nonmem/nm-ctl/index.qmd
+++ b/docs/tools-of-the-trade/nonmem/nm-ctl/index.qmd
@@ -152,7 +152,7 @@ IF (CP > CMAXM) THEN
 ENDIF
 ```
 
-![](./images/tmax-vs-dt.png)
+<!-- TODO: Add image ./images/tmax-vs-dt.png -->
 
 |          | Total CPU time(s) |
 | :------- | :---: |

--- a/docs/tools-of-the-trade/r/r-tips-n-tricks/index.qmd
+++ b/docs/tools-of-the-trade/r/r-tips-n-tricks/index.qmd
@@ -204,4 +204,4 @@ plot(layers)
         * any: `NA %in% vector`
         * sum: `vector %in% NA %>% sum`
 
-![](./images/dist-func.png)
+<!-- TODO: Add image ./images/dist-func.png -->

--- a/docs/workbench/index.qmd
+++ b/docs/workbench/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Workbench"
+description: "Interactive pharmacometrics tools and calculators for unit conversion, half-life calculations, and PK parameter estimation."
 date: last-modified
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,15 @@
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
+## Security headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "SAMEORIGIN"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
 ## Force canonical host: apex (vrognas.com)
 ## Redirect all www traffic to apex with 301
 [[redirects]]

--- a/seo.html
+++ b/seo.html
@@ -122,8 +122,8 @@
 <meta property="article:section" content="Pharmacometrics">
 
 <!-- Additional meta tags for better SEO -->
-<meta name="theme-color" content="#007bff">
-<meta name="msapplication-TileColor" content="#007bff">
+<meta name="theme-color" content="#1D2021">
+<meta name="msapplication-TileColor" content="#1D2021">
 
 <!-- Enhanced GA4 measurement -->
 <script>


### PR DESCRIPTION
- Add HTTP security headers to netlify.toml (HSTS, X-Content-Type-Options,
  X-Frame-Options, Referrer-Policy)
- Fix theme-color meta tags in seo.html (#007bff → #1D2021)
- Fix broken image reference in clinpharm-studies (missing .png extension)
- Comment out 5 missing image references with TODO markers
- Add meta descriptions to 9 section index pages for improved SEO